### PR TITLE
add debug utils; fix monster hp issue

### DIFF
--- a/app/Init.hs
+++ b/app/Init.hs
@@ -39,7 +39,10 @@ initialState =
       monsters = [Monster 10 10 "Goblin Raider" 30 8, Monster 5 5 "Forest Nymph" 20 6, Monster 10 17 "Mountain Troll" 50 10, Monster 15 15 "Shadow Assassin" 40 12],
       inMonster = Nothing,
       gameOver = False,
-      mountains = [Mountain 1 2, Mountain 1 3, Mountain 1 4, Mountain 1 5, Mountain 2 5]
+      mountains = [Mountain 1 2, Mountain 1 3, Mountain 1 4, Mountain 1 5, Mountain 2 5],
+      -- set it to True to display debug messages
+      displayLogs = False,
+      logs = []
     }
 
 initialEvents :: [GameEvent]

--- a/cse230.cabal
+++ b/cse230.cabal
@@ -25,6 +25,7 @@ source-repository head
 
 library
   exposed-modules:
+      Debug
       Types
   other-modules:
       Paths_cse230

--- a/src/Debug.hs
+++ b/src/Debug.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Debug where
+
+import Types
+
+appendLogToGame :: String -> Game -> Game
+appendLogToGame s game = game {logs = logs game ++ [s]}
+
+appendLogsToGame :: [String] -> Game -> Game
+appendLogsToGame ss game = game {logs = logs game ++ ss}
+
+appendKeyValueLogToGame :: String -> String -> Game -> Game
+appendKeyValueLogToGame k v game = game {logs = logs game ++ [k ++ ": " ++ v]}
+
+appendLog :: String -> [String] -> [String]
+appendLog msg l = l ++ [msg]
+
+appendKeyValueLog :: String -> String -> [String] -> [String]
+appendKeyValueLog k v l = l ++ [k ++ ": " ++ v]

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -24,7 +24,10 @@ data Game = Game
     -- it after it is defeated
     inMonster :: Maybe Monster,
     gameOver :: Bool,
-    mountains :: [Mountain]
+    mountains :: [Mountain],
+    -- debug logs
+    displayLogs :: Bool,
+    logs :: [String]
   }
 
 data GameEvent = GEvent


### PR DESCRIPTION
The main functionality that this PR adds is an optional debug console which displays any strings. To use the debug console, set the `displayLogs` attribute in game state to be true and then use helper functions in `Debug.hs` to add debug messages. An example is in `fightMonster`. With the debug console, the monster hp issue is fixed.